### PR TITLE
Various selfmedicate fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.retry
 hosts
 venv/
+.idea/
 
 # This is where I placed my updated gcp provider
 terraform.d/

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 *.retry
 hosts
 venv/
-.idea/
 
 # This is where I placed my updated gcp provider
 terraform.d/

--- a/anti-up.sh
+++ b/anti-up.sh
@@ -21,7 +21,7 @@ fi
 echo "Creating minikube cluster. This can take a few minutes, please be patient..."
 minikube stop > /dev/null
 minikube delete > /dev/null
-minikube start --loglevel 0 --cpus 4 --memory 8192 --network-plugin=cni --extra-config=kubelet.network-plugin=cni > /dev/null
+minikube start --cpus 4 --memory 8192 --network-plugin=cni --extra-config=kubelet.network-plugin=cni > /dev/null
 
 echo "Uploading multus configuration..."
 scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $(minikube ssh-key) multus-cni.conf docker@$(minikube ip):/home/docker/multus.conf  > /dev/null
@@ -41,4 +41,4 @@ kubectl create -f antidote-web.yaml > /dev/null
 
 echo "${GREEN}Finished!${NC} Antidote is being spun up right now. Soon, it will be available at:
 
-http://antidote-local:30001/"
+https://antidote-local:30002/"

--- a/antidote-web.yaml
+++ b/antidote-web.yaml
@@ -1,39 +1,45 @@
 ---
-apiVersion: v1
-kind: Pod
-metadata:
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata: 
   name: antidote-web
-  labels:
-    app: antidote-web
-    antidote_role: infra
-spec:
-  containers:
-  - name: guacd
-    image: guacamole/guacd
-    ports:
-    - containerPort: 4822
-  - name: antidote-web
-    image: antidotelabs/antidote-web:latest
-    imagePullPolicy: Always
-    env:
-    - name: GUACD_HOSTNAME
-      value: "127.0.0.1"
-    - name: GUACD_PORT
-      value: "4822"
-    - name: POSTGRES_HOSTNAME
-      value: "na"
-    - name: POSTGRES_DATABASE
-      value: "na"
-    - name: POSTGRES_USER
-      value: "na"
-    - name: POSTGRES_PASSWORD
-      value: "na"
-    ports:
-    - containerPort: 8080
-    readinessProbe:
-      httpGet:
-        path: /
-        port: 8080
+spec: 
+  replicas: 1
+  revisionHistoryLimit: 3
+  template: 
+    metadata:
+      name: antidote-web
+      labels:
+        app: antidote-web
+        antidote_role: infra
+    spec:
+      containers:
+      - name: guacd
+        image: guacamole/guacd
+        ports:
+        - containerPort: 4822
+      - name: antidote-web
+        image: antidotelabs/antidote-web:latest
+        imagePullPolicy: Always
+        env:
+        - name: GUACD_HOSTNAME
+          value: "127.0.0.1"
+        - name: GUACD_PORT
+          value: "4822"
+        - name: POSTGRES_HOSTNAME
+          value: "na"
+        - name: POSTGRES_DATABASE
+          value: "na"
+        - name: POSTGRES_USER
+          value: "na"
+        - name: POSTGRES_PASSWORD
+          value: "na"
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
 
 ---
 kind: Service

--- a/antidote-web.yaml
+++ b/antidote-web.yaml
@@ -53,7 +53,7 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
-  type: LoadBalancer
+  type: ClusterIP
 
 ---
 apiVersion: extensions/v1beta1
@@ -62,12 +62,10 @@ metadata:
   annotations:
     ingress.kubernetes.io/ingress.class: "nginx"
     ingress.kubernetes.io/ssl-services: "antidote-web"
-    ingress.kubernetes.io/ssl-redirect: "false"
-    ingress.kubernetes.io/force-ssl-redirect: "false"
-    # ingress.kubernetes.io/rewrite-target: "/antidote-web"
-    # nginx.ingress.kubernetes.io/rewrite-target: "/antidote-web"
-    # ingress.kubernetes.io/limit-connections
-    # ingress.kubernetes.io/limit-rps
+    ingress.kubernetes.io/ssl-redirect: "true"
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/limit-connections: "10"
+    nginx.ingress.kubernetes.io/limit-rps: "5"
   name: antidote-web-ingress
   namespace: default
 spec:

--- a/nginx-controller.yaml
+++ b/nginx-controller.yaml
@@ -152,10 +152,6 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - name: http
-    port: 80
-    nodePort: 30001
-    targetPort: http
   - name: https
     port: 443
     nodePort: 30002

--- a/syringe.yml
+++ b/syringe.yml
@@ -115,6 +115,8 @@ spec:
           value: "/antidote/lessons"
         - name: SYRINGE_IGNORE_DISABLED
           value: "true"
+        - name: SYRINGE_TIER
+          value: "local"
         ports:
         - containerPort: 50099  # GRPC
         - containerPort: 8086   # REST/HTTP

--- a/syringe.yml
+++ b/syringe.yml
@@ -158,9 +158,7 @@ spec:
     - name: http
       port: 8086
       targetPort: 8086
-      # nodePort: 30011
-  type: LoadBalancer
-  # type: NodePort
+  type: ClusterIP
 
 ---
 apiVersion: extensions/v1beta1
@@ -178,6 +176,9 @@ metadata:
   name: syringe-ingress
   namespace: default
 spec:
+  tls:
+    - hosts:
+      - antidote-local
   rules:
   - host: "antidote-local"
     http:


### PR DESCRIPTION
- Updated syringe deployment with missing env var
- Converted syringe to `Deployment` to be consistent with other resources
- Force HTTPS to get around crappy performance issues when using HTTP. Need to troubleshoot this later but the problem seem to go away with HTTPS, so, good for now.