### PR TITLE
Update preloaded images

### DIFF
--- a/selfmedicate.sh
+++ b/selfmedicate.sh
@@ -21,7 +21,7 @@ VMDRIVER=${VMDRIVER:="virtualbox"}
 LESSON_DIRECTORY=${LESSON_DIRECTORY:="../nrelabs-curriculum"}
 MINIKUBE=${MINIKUBE:="minikube"}
 KUBECTL=${KUBECTL:="kubectl"}
-PRELOADED_IMAGES=${PRELOADED_IMAGES:="vqfx:snap1 vqfx:snap2 vqfx:snap3 utility"}
+PRELOADED_IMAGES=${PRELOADED_IMAGES:="vqfx-snap1 vqfx-snap2 vqfx-snap3 utility"}
 
 # Checking for prerequisites
 command -v $MINIKUBE > /dev/null


### PR DESCRIPTION
Per the changes described in https://github.com/nre-learning/nrelabs-curriculum/pull/248, this PR updates the preloaded images list in selfmedicate. As the curriculum PR states, the images are identical, just retagged with a new name.