### PR TITLE
Pin to platform v0.4.0

### DIFF
--- a/manifests/antidote-web.yaml
+++ b/manifests/antidote-web.yaml
@@ -19,7 +19,7 @@ spec:
         ports:
         - containerPort: 4822
       - name: antidote-web
-        image: antidotelabs/antidote-web:latest
+        image: antidotelabs/antidote-web:release-v0.4.0
         imagePullPolicy: Always
         env:
         - name: GUACD_HOSTNAME

--- a/manifests/syringe-k8s.yaml
+++ b/manifests/syringe-k8s.yaml
@@ -55,15 +55,15 @@ spec:
       serviceAccount: syringesa
       containers:
       - name: syringe
-        image: antidotelabs/syringe:latest
+        image: antidotelabs/syringe:release-v0.4.0
         imagePullPolicy: Always
         env:
-        - name: SYRINGE_CURRICULUM
-          value: "/antidote"
         - name: SYRINGE_DOMAIN
-          value: "antidote-local"
+          value: antidote-local
+        - name: SYRINGE_CURRICULUM
+          value: /antidote
         - name: SYRINGE_TIER
-          value: "local"
+          value: local
         - name: SYRINGE_CURRICULUM_LOCAL
           value: "true"
         ports:


### PR DESCRIPTION
To facilitate stable curriculum development, we're going to set selfmedicate to pull the latest *stable* release of the platform, rather than work on the `latest` copies.

This PR sets selfmedicate to use v0.4.0, released a few days ago.