### PR TITLE
Removed pointless copyright line in license file.  #35

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Copyright 2018 Juniper Networks Inc.
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
Removed Juniper copyright line from Apache 2.0 license file.  Juniper does not own a copyright on that license.