### PR TITLE
Use synced_folder instead of file which is buggy in older Vagrant versions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,7 +100,9 @@ Vagrant.configure("2") do |config|
   
   # Copy selfmedicate and the manifests folder to the VM.
   config.vm.provision "file", source: "selfmedicate.sh", destination: "$HOME/selfmedicate.sh"
-  config.vm.provision "file", source: "manifests", destination: "$HOME/manifests"
+  #config.vm.provision "file", source: "manifests", destination: "$HOME/manifests"
+  # Woraround bug in older Vagrant versions using rsync instead of file
+  config.vm.synced_folder "manifests", "/home/vagrant/manifests"
   
   # Provisioning antidote vagrant vm
   # This will install docker, kubectl and minikube


### PR DESCRIPTION
Proposed fix for #55 
The scp is buggy in older Vagrant versions, so rsync should better (or
any other default, like for #41)