### PR TITLE
Add libvirt provider options

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,6 +70,14 @@ Vagrant.configure("2") do |config|
     v.vmx["numvcpus"] = antidote_config['vm_config']['cores']
   end
 
+  # Configuration options for Libvirt.
+  config.vm.provider :libvirt do |v, override|
+    v.memory = antidote_config['vm_config']['memory']
+    v.cpus = antidote_config['vm_config']['cores']
+    v.nested = true
+    override.vm.config = "generic/ubuntu1604"
+  end
+
 
   # Base Ubuntu Box
   config.vm.box = "bento/ubuntu-16.04"


### PR DESCRIPTION
to Vagrantfile

Issue: https://github.com/nre-learning/antidote-selfmedicate/issues/47

I have been using Libvirt to run antidote-selfmedicate. Libvirt works well when you install the vagrant-libvirt plugin. However, we need to add the Libvirt provider options to the Vagantfile so vagrant uses a compatible box and reads the options in antidote-config.yml. The changes I propose have no impact on other providers.