### PR TITLE
Remove requirement for a specific hostname

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,6 +86,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "Antidote #{antidote_config['version']}"
 
+  # Warning, this interface is referred to  in selfmedicate.sh, and used to display the address through which
+  # the user can access `antidote-web`. Change with caution.
   config.vm.network :private_network, id: "antidote_primary", ip: antidote_config['vm_config']['private_network_ip']
 
   config.vm.network "forwarded_port", guest: 30001, host: 30001

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,12 +86,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "Antidote #{antidote_config['version']}"
 
-  # Please see (https://github.com/cogitatio/vagrant-hostsupdater) for more information
-  if defined?(VagrantPlugins::HostsUpdater)
-     config.hostsupdater.aliases = ["antidote-local"]
-     config.hostsupdater.remove_on_suspend = false
-  end
-
   config.vm.network :private_network, id: "antidote_primary", ip: antidote_config['vm_config']['private_network_ip']
 
   config.vm.network "forwarded_port", guest: 30001, host: 30001

--- a/manifests/antidote-web.yaml
+++ b/manifests/antidote-web.yaml
@@ -70,8 +70,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - host: "antidote-local"
-    http:
+  - http:
       paths:
       - path: "/"
         backend:

--- a/manifests/syringe-k8s.yaml
+++ b/manifests/syringe-k8s.yaml
@@ -110,12 +110,8 @@ metadata:
   name: syringe-ingress
   namespace: default
 spec:
-  tls:
-    - hosts:
-      - antidote-local
   rules:
-  - host: "antidote-local"
-    http:
+  - http:
       paths:
       - path: "/syringe"
         backend:

--- a/selfmedicate.sh
+++ b/selfmedicate.sh
@@ -68,7 +68,7 @@ sub_resume(){
         --extra-config=kubelet.network-plugin=cni \
         --kubernetes-version=$K8SVERSION
 
-    echo -e "${GREEN}Finished!${NC} Antidote should now be available at http://192.168.34.100:30001/"
+    echo -e "${GREEN}Finished!${NC} Antidote should now be available at http://$(ip addr show eth1 | grep "inet " | sed -E 's/.*inet (.*)\/.*/\1/'):30001/"
 }
 
 sub_start(){
@@ -170,7 +170,7 @@ sub_start(){
     echo -ne "$pc%\033[0K\r"
     echo -ne $(print_progress 1) "${GREEN}Done.${NC}\n"
 	# Moved antidote up message to before image pull due to docker timeout issues.
-    echo -e "${GREEN}Finished!${NC} Antidote should now be available at http://192.168.34.100:30001/"
+    echo -e "${GREEN}Finished!${NC} Antidote should now be available at http://$(ip addr show eth1 | grep "inet " | sed -E 's/.*inet (.*)\/.*/\1/'):30001/"
 
     # Pre-download large common images
     for i in $(echo $PRELOADED_IMAGES)

--- a/selfmedicate.sh
+++ b/selfmedicate.sh
@@ -68,7 +68,7 @@ sub_resume(){
         --extra-config=kubelet.network-plugin=cni \
         --kubernetes-version=$K8SVERSION
 
-    echo -e "${GREEN}Finished!${NC} Antidote should now be available at http://antidote-local:30001/"
+    echo -e "${GREEN}Finished!${NC} Antidote should now be available at http://192.168.34.100:30001/"
 }
 
 sub_start(){
@@ -170,7 +170,7 @@ sub_start(){
     echo -ne "$pc%\033[0K\r"
     echo -ne $(print_progress 1) "${GREEN}Done.${NC}\n"
 	# Moved antidote up message to before image pull due to docker timeout issues.
-    echo -e "${GREEN}Finished!${NC} Antidote should now be available at http://antidote-local:30001/"
+    echo -e "${GREEN}Finished!${NC} Antidote should now be available at http://192.168.34.100:30001/"
 
     # Pre-download large common images
     for i in $(echo $PRELOADED_IMAGES)


### PR DESCRIPTION
This removes the requirement for a specific hostname in the ingress definitions, and then also removes the logic to work with the `/etc/hosts` file, because it's not needed anymore.

Closes https://github.com/nre-learning/antidote-selfmedicate/issues/52