### PR TITLE
Normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This Pull Request will add the .gitattributes file to force git to use Unix style line endings for the shell provisioners.

Closes #50 