### PR TITLE
Fixes "shared folder guest path must be absolute"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,7 +111,7 @@ Vagrant.configure("2") do |config|
   # Copy selfmedicate and the manifests folder to the VM.
   config.vm.provision "file", source: "selfmedicate.sh", destination: "$HOME/selfmedicate.sh"
   config.vm.provision "file", source: "container-start.sh", destination: "$HOME/container-start.sh"
-  config.vm.synced_folder "manifests", "$HOME/manifests"
+  config.vm.synced_folder "manifests", "/home/vagrant/manifests"
   
   # Provisioning antidote vagrant vm
   # This will install docker, kubectl and minikube


### PR DESCRIPTION
Apparently, the synced_folder doesn't like env variables.